### PR TITLE
Typo fix (Northrup -> Northup)

### DIFF
--- a/images/cover.svg
+++ b/images/cover.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" viewBox="0 0 1400 2100">
-	<title>The cover for the Standard Ebooks edition of Twelve Years a Slave, by Solomon Northrup</title>
+	<title>The cover for the Standard Ebooks edition of Twelve Years a Slave, by Solomon Northup</title>
 	<style type="text/css">
 		.title-box{
 			fill-opacity: .75;
@@ -25,5 +25,5 @@
 	<path class="title-box" d="M 50,1620 1350,1620 1350,2050 50,2050 Z"/>
 	<text class="title" x="700" y="1775">TWELVE YEARS</text>
 	<text class="title" x="700" y="1875">A SLAVE</text>
-	<text class="author" x="700" y="1975">SOLOMON NORTHRUP</text>
+	<text class="author" x="700" y="1975">SOLOMON NORTHUP</text>
 </svg>

--- a/images/titlepage.svg
+++ b/images/titlepage.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 1400 440">
-	<title>The titlepage for the Standard Ebooks edition of Twelve Years a Slave, by Solomon Northrup</title>
+	<title>The titlepage for the Standard Ebooks edition of Twelve Years a Slave, by Solomon Northup</title>
 	<style type="text/css">
 		text{
 			font-family: "League Spartan";
@@ -18,5 +18,5 @@
 	</style>
 	<text class="title" x="700" y="130">TWELVE YEARS</text>
 	<text class="title" x="700" y="230">A SLAVE</text>
-	<text class="author" x="700" y="390">SOLOMON NORTHRUP</text>
+	<text class="author" x="700" y="390">SOLOMON NORTHUP</text>
 </svg>

--- a/src/epub/text/appendix.xhtml
+++ b/src/epub/text/appendix.xhtml
@@ -47,7 +47,7 @@
 					<p>That your memorialist and her family are poor and wholly unable to pay or sustain any portion of the expenses of restoring the said Solomon to his freedom.</p>
 					<p>Your excellency is entreated to employ such agent or agents as shall be deemed necessary to effect the restoration and return of said Solomon Northup, in pursuance of an act of the Legislature of the State of New York, passed May 14th, 1840, entitled “An act more effectually to protect the free citizens of this State from being kidnappd or reduced to slavery.” And your memorialist will ever pray.</p>
 					<footer>
-						<p>(Signed) <span epub:type="z3998:sender z3998:signature">Anne Northrup</span></p>
+						<p>(Signed) <span epub:type="z3998:sender z3998:signature">Anne Northup</span></p>
 						<p>Dated November 19, 1852.</p>
 					</footer>
 				</blockquote>

--- a/src/epub/text/titlepage.xhtml
+++ b/src/epub/text/titlepage.xhtml
@@ -7,7 +7,7 @@
 	</head>
 	<body epub:type="frontmatter">
 		<section id="titlepage" epub:type="titlepage">
-			<img alt="The titlepage for the Standard Ebooks edition of Twelve Years a Slave, by Solomon Northrup" src="../images/titlepage.svg" epub:type="se:color-depth.black-on-transparent"/>
+			<img alt="The titlepage for the Standard Ebooks edition of Twelve Years a Slave, by Solomon Northup" src="../images/titlepage.svg" epub:type="se:color-depth.black-on-transparent"/>
 		</section>
 	</body>
 </html>


### PR DESCRIPTION
Simple stuff, just fixing the usage of "Northrup" in the title page SVGs, the opening page, and once in the appendix.